### PR TITLE
replace proc macros with matching macros use macro_metavar_expr feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,3 @@ edition = "2021"
 authors = ["Carter Canedy <cartercanedy42@gmail.com>"]
 repository = "https://github.com/cartercanedy/zips"
 license = "MIT"
-
-[lib]
-proc-macro = true
-
-[dependencies]
-proc-macro2 = "1.0.86"
-quote = "1.0.36"
-syn = { version = "~2.0.77", features = ["parsing", "derive", "proc-macro", "printing"], default-features = false }


### PR DESCRIPTION
Currently, metavariable expressions are a nightly-only feature, but stabilization has been proposed and should be mainlined later this year. Merge this branch when feature macro_metavar_expr is actually stable.